### PR TITLE
Merge recent PHYRE changes to config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,34 +9,28 @@ jobs:
       # Create conda env with all deps.
       - restore_cache:
           keys:
-            - v2-conda-{{ checksum "env.yml" }}
+            - v3-conda-{{ checksum "env.yml" }}
       - run:
          command: |
           if [[ ! -d "/opt/conda/envs/phyre/" ]]; then
             conda env create -f env.yml
           fi
       - save_cache:
-          key: v2-conda-{{ checksum "env.yml" }}
+          key: v3-conda-{{ checksum "env.yml" }}
           paths: /opt/conda/envs/phyre/
-
-      # Restore node cache.
-      - restore_cache:
-          keys:
-            - v1-npm-{{ checksum "src/viz/package.json" }}-{{ checksum "src/viz/package-lock.json" }}
 
       # Install phyre.
       - run:
          command: |
            apt-get update
-           apt-get install build-essential --yes
+           # Due to ABI incompability of the conda's boost and circle ci image,
+           # use boost from the image.
+           apt-get install build-essential libboost-all-dev --yes
            conda init bash
            . ~/.bashrc
            conda activate phyre
+           conda uninstall boost boost-cpp --yes
            pip install -e src/python
-      # Save node package cache.
-      - save_cache:
-          key: v1-npm-{{ checksum "src/viz/package.json" }}-{{ checksum "src/viz/package-lock.json" }}
-          paths: src/viz/node_modules/
 
       # Run tests.
       - run:

--- a/env.yml
+++ b/env.yml
@@ -5,10 +5,11 @@ dependencies:
   - python=3.6
   - sed
   - nodejs
-  - thrift-cpp
+  - thrift-cpp=0.11.0
+  - wget
   - pybind11=2.2.4
   - cmake
-  - boost
+  - boost=1.67.0
   - setuptools
   - pip
   - pip:

--- a/src/python/phyre/vis.py
+++ b/src/python/phyre/vis.py
@@ -98,7 +98,7 @@ def save_observation_series_to_gif(batched_observation_series,
         images_for_step = np.concatenate(images_for_step, axis=1)
         images_per_step.append(images_for_step)
 
-    imageio.mimwrite(fpath, images_per_step)
+    imageio.mimwrite(fpath, images_per_step, format="gif")
 
 
 def compose_gifs_compact(input_fpathes, output_fpath):

--- a/src/python/setup.py
+++ b/src/python/setup.py
@@ -70,8 +70,8 @@ setuptools.setup(name='phyre',
                  },
                  packages=['phyre', 'phyre.creator', 'phyre.viz_server'],
                  install_requires=[
-                     'nose', 'numpy', 'tornado', 'thrift', 'imageio', 'scipy',
-                     'joblib'
+                     'nose', 'numpy', 'tornado', 'thrift==0.11.0', 'imageio',
+                     'scipy', 'joblib'
                  ],
                  cmdclass={'build_ext': build_ext},
                  classifiers=[


### PR DESCRIPTION
Seems like the PHYRE folks update some of the config files just yesterday, and it makes the difference between me being able to build from source vs. not yesterday. Since running the web app depends on where the phyre library is built, I need to be able to install it from this source. It seems this will only change config files and shouldn't affect any ongoing work.